### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 version = "0.5.3"
 authors = ["Jonathan Dizdarevic <dizzda@gmail.com>"]
 edition = "2021"
+repository = "https://github.com/dizda/amqp-lapin-helper"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link to it